### PR TITLE
test(ontology of Rosetta): delete reference to "anything" (DSP-511)

### DIFF
--- a/rosetta.json
+++ b/rosetta.json
@@ -192,7 +192,7 @@
            "password": "rosetta1234",
            "lang": "de",
            "groups": [":rosetta-editors"],
-           "projects": [":admin","anything:member"]
+           "projects": [":admin",":member"]
          }
        ],      
       "ontologies": [

--- a/rosetta.json
+++ b/rosetta.json
@@ -192,7 +192,7 @@
            "password": "rosetta1234",
            "lang": "de",
            "groups": [":rosetta-editors"],
-           "projects": [":admin",":member"]
+           "projects": [":admin"]
          }
        ],      
       "ontologies": [


### PR DESCRIPTION
When dsp-api is set up with `make init-db-test-minimal`, no projects are loaded, so the reference to "anything" will throw an error which is hard to trace back