### PR TITLE
Update rosetta.json

### DIFF
--- a/rosetta.json
+++ b/rosetta.json
@@ -179,7 +179,7 @@
     "groups": [
       {
         "name": "rosetta-editors",
-        "description": "Editors for the rosetta-project",
+        "descriptions": {"en":"Editors for the rosetta-project"},
         "selfjoin": false,
         "status": true
       }


### PR DESCRIPTION
There was a change in the data model for groups: 
 - `descriptions` instead of `description` is expected
 - language strings instead of simple strings are required