### PR TITLE
Add comments to list

### DIFF
--- a/rosetta.json
+++ b/rosetta.json
@@ -64,6 +64,10 @@
           "en": "Category",
           "fr": "Catégorie"
         },
+        "comments": {
+          "en": "A list containing categories",
+          "de": "Die Liste enthält Kategorien"
+        },
         "nodes": [
           {
             "name": "artwork",


### PR DESCRIPTION
`comments` is mandatory according to the documentation (https://docs.dasch.swiss/DSP-API/03-apis/api-admin/lists/#create-new-list) and is enforced now by the API.