### PR TITLE
Adding time property

### DIFF
--- a/rosetta.json
+++ b/rosetta.json
@@ -59,6 +59,9 @@
     "lists": [
       {
         "name": "category",
+        "comments": {
+          "en": "no comment"
+        },
         "labels": {
           "de": "Kategorie",
           "en": "Category",
@@ -205,6 +208,19 @@
         "name": "rosetta",
         "label": "The rosetta ontology",
         "properties": [
+          {
+            "name": "hasTime",
+            "super": [
+              "hasValue"
+            ],
+            "object": "TimeValue",
+            "labels": {
+              "de": "Zeit",
+              "en": "Time",
+              "fr": "Heure"
+            },
+            "gui_element": "TimeStamp"
+          },
           {
             "name": "hasText",
             "super": [
@@ -1206,6 +1222,11 @@
                 "propname": ":hasExternalLink",
                 "cardinality": "0-n",
                 "gui_order": 4
+              },
+              {
+                "propname": ":hasTime",
+                "cardinality": "0-1",
+                "gui_order": 5
               }
             ]
           },

--- a/rosetta.xml
+++ b/rosetta.xml
@@ -43,6 +43,9 @@
         <uri-prop name=":hasExternalLink">
             <uri permissions="prop-default">https://en.wikipedia.org/wiki/Homer</uri>
         </uri-prop>
+        <time-prop name=":hasTime">
+            <time permissions="prop-default">1990-05-23T13:45:12Z</time>
+        </time-prop>
     </resource>
 
     <resource label="Fernand Léger" restype=":Person" id="person_1" permissions="res-default">
@@ -55,6 +58,9 @@
         <uri-prop name=":hasExternalLink">
             <uri permissions="prop-default">http://fr.wikipedia.org/wiki/Fernand_Léger</uri>
         </uri-prop>
+        <time-prop name=":hasTime">
+            <time permissions="prop-default">1881-02-04T12:00:00-02:00</time>
+        </time-prop>
     </resource>
 
     <resource label="Francis Danby" restype=":Person" id="person_2" permissions="res-default">
@@ -67,6 +73,9 @@
         <uri-prop name=":hasExternalLink">
             <uri permissions="prop-default">https://en.wikipedia.org/wiki/Francis_Danby</uri>
         </uri-prop>
+        <time-prop name=":hasTime">
+            <time permissions="prop-default">0099-07-18T16:00:00Z</time>
+        </time-prop>
     </resource>
 
     <resource label="Paul Éluard" restype=":Person" id="person_3" permissions="res-default">
@@ -94,6 +103,9 @@
         <uri-prop name=":hasExternalLink">
             <uri permissions="prop-default">https://en.wikipedia.org/wiki/Matsuo_Bash%C5%8D</uri>
         </uri-prop>
+        <time-prop name=":hasTime">
+            <time permissions="prop-default">0006-06-06T06:06:06-06:00</time>
+        </time-prop>
     </resource>
 
     <resource label="Ivan Krylov" restype=":Person" id="person_5" permissions="res-default">
@@ -116,6 +128,7 @@
             <uri permissions="prop-default">http://d-nb.info/gnd/1148770291</uri>
         </uri-prop>
     </resource>
+
     <resource label="Goran Bregović" restype=":Person" id="person_7" permissions="res-default">
         <text-prop name=":hasName">
             <text permissions="prop-default" encoding="utf8">Goran Bregović</text>


### PR DESCRIPTION
I extended the rosetta scripts with time properties by doing 2 things:
1. Defining `hasTime` property in the ontology
2. Adding `<time-prop>...</time-prop>` with the data in the xml file

Note:
In the rosetta.json file (lines 62-64) I added the comments, because currently with the dsp-tools v.1.5.1 there was an issue with comments. By adding these lines and modifying some code in dsp-tools the import was successful. 