### PR TITLE
fix isAnnotationOf, add gui_element Radio

### DIFF
--- a/rosetta.json
+++ b/rosetta.json
@@ -735,11 +735,11 @@
             "gui_element": "SimpleText"
           },
           {
-            "name": "isAnnotationOf",
+            "name": "isAnnotationOfObject",
             "super": [
               "isAnnotationOf"
             ],
-            "object": "Resource",
+            "object": ":Object",
             "labels": {
               "de": "Annotation",
               "en": "Annotation",
@@ -1483,7 +1483,7 @@
                 "gui_order": 1
               },
               {
-                "propname": ":isAnnotationOf",
+                "propname": ":isAnnotationOfObject",
                 "cardinality": "1",
                 "gui_order": 2
               }

--- a/rosetta.json
+++ b/rosetta.json
@@ -57,6 +57,29 @@
     ],
     "lists": [
       {
+        "name": "flatlist",
+        "labels": {
+          "en": "Flat list"
+        },
+        "comments": {
+          "en": "Flat list"
+        },
+        "nodes": [
+          {
+            "name": "first-node",
+            "labels": {
+              "en": "First node"
+            }
+          },
+          {
+            "name": "second-node",
+            "labels": {
+              "en": "Second node"
+            }
+          }
+        ]
+      },
+      {
         "name": "category",
         "labels": {
           "de": "Kategorie",
@@ -603,6 +626,22 @@
             "gui_element": "List",
             "gui_attributes": {
               "hlist": "category"
+            }
+          },
+          {
+            "name": "hasFlatList",
+            "super": [
+              "hasValue"
+            ],
+            "object": "ListValue",
+            "labels": {
+              "de": "Flatlist",
+              "en": "Flatlist",
+              "fr": "Flatlist"
+            },
+            "gui_element": "Radio",
+            "gui_attributes": {
+              "hlist": "flatlist"
             }
           },
           {
@@ -1308,6 +1347,11 @@
               },
               {
                 "propname": ":hasCategory",
+                "cardinality": "0-n",
+                "gui_order": 1
+              },
+              {
+                "propname": ":hasFlatList",
                 "cardinality": "0-n",
                 "gui_order": 1
               },

--- a/rosetta.xml
+++ b/rosetta.xml
@@ -1648,6 +1648,10 @@
         <list-prop list="category" name=":hasCategory">
             <list permissions="prop-default">artwork</list>
         </list-prop>
+        <list-prop list="flatlist" name=":hasFlatList">
+            <list permissions="prop-default">first-node</list>
+            <list permissions="prop-default">second-node</list>
+        </list-prop>
         <text-prop name=":hasName">
             <text permissions="prop-default" encoding="utf8">lekythos</text>
         </text-prop>
@@ -1693,6 +1697,9 @@
             <list permissions="prop-default">nature</list>
             <list permissions="prop-default">animals</list>
             <list permissions="prop-default">mammals</list>
+        </list-prop>
+        <list-prop list="flatlist" name=":hasFlatList">
+            <list permissions="prop-default">first-node</list>
         </list-prop>
         <text-prop name=":hasName">
             <text permissions="prop-default" encoding="utf8">Demonstration of multiple cardinalities</text>

--- a/rosetta.xml
+++ b/rosetta.xml
@@ -1750,7 +1750,7 @@
         <text-prop name=":hasComment">
             <text encoding="utf8" permissions="prop-default">This is an annotation to the object 'Multiple cardinality demonstration'.</text>
         </text-prop>
-        <resptr-prop name=":isAnnotationOf">
+        <resptr-prop name=":isAnnotationOfObject">
             <resptr permissions="prop-default">obj_3</resptr>
         </resptr-prop>
     </resource>


### PR DESCRIPTION
This PR makes it possible to create rosetta.json without errors, by changing `isAnnotationOf` to `isAnnotationOfObject`. 
 - rationale: The superclass `isAnnotationOf` requires a cardinality of 1-n or 1. But the onto validation requires a cardinality of 0-n or 0-1, because of the circularity check which requires circular properties to be temporarily stashed.

This PR further demonstrates `"gui_element": "Radio"` for lists. While it is true that DSP-APP doesn't make a difference between `"gui_element": "List"` and `"gui_element": "Radio"`, the difference exists in DSP-API, and also in DSP-TANGOH, so it makes sense to add it to rosetta.