### PR TITLE
remove technical stuff, make images of Deluge and Liberté publicly visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lists-only.json
 .idea/
 env/
 id2iri_*.json
+stashed_*.txt

--- a/rosetta.xml
+++ b/rosetta.xml
@@ -291,7 +291,7 @@
     </resource>
 
     <resource label="Deluge" restype=":Image2D" id="img_obj_1" permissions="res-default">
-        <bitstream permissions="prop-restricted">Images/Danby-deluge.jpg</bitstream>
+        <bitstream permissions="prop-default">Images/Danby-deluge.jpg</bitstream>
         <text-prop name=":hasTitle">
             <text permissions="prop-default" encoding="utf8">The Deluge</text>
         </text-prop>
@@ -324,7 +324,7 @@
     </resource>
 
     <resource label="Liberté, j'écris ton nom" restype=":Image2D" id="img_obj_2" permissions="res-default">
-        <bitstream>Images/Leger-Eluard.jpg</bitstream>
+        <bitstream permissions="prop-default">Images/Leger-Eluard.jpg</bitstream>
         <text-prop name=":hasTitle">
             <text permissions="prop-default" encoding="utf8">Liberté</text>
         </text-prop>

--- a/rosetta.xml
+++ b/rosetta.xml
@@ -272,22 +272,6 @@
                 story of the deluge. The tablet was found at Koyunjik in the Library of Ashurbanipal and it dates to
                 the 7<sup>th</sup> century BCE.
             </text>
-            <text permissions="prop-default" encoding="xml">
-                Variations of the &lt;bitstream&gt;-Tag:
-                <ul>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Liberté, j'écris ton nom" has no "permissions"
-                        attribute, so an UnknownUser has no rights at all. A user who is not logged in doesn't see the
-                        image at all.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Deluge" has permissions="prop-restricted", which gives
-                        an UnknownUser the right "RV" (Restricted view permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in should see a blurred image.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "BM K.3375" has permissions="prop-default", which gives
-                        an UnknownUser the right "V" (View permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in sees the image in full resolution.</li>
-                </ul>
-            </text>
         </text-prop>
         <text-prop name=":hasCopyright">
             <text permissions="prop-default" encoding="utf8">© The Trustees of the British Museum</text>
@@ -322,22 +306,6 @@
                 Oil paint on canvas. The subject is from the book Genesis in the Old Testament. God sends a flood and
                 spares only Noah and his family.
             </text>
-            <text permissions="prop-default" encoding="xml">
-                Variations of the &lt;bitstream&gt;-Tag:
-                <ul>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Liberté, j'écris ton nom" has no "permissions"
-                        attribute, so an UnknownUser has no rights at all. A user who is not logged in doesn't see the
-                        image at all.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Deluge" has permissions="prop-restricted", which gives
-                        an UnknownUser the right "RV" (Restricted view permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in should see a blurred image.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "BM K.3375" has permissions="prop-default", which gives
-                        an UnknownUser the right "V" (View permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in sees the image in full resolution.</li>
-                </ul>
-            </text>
         </text-prop>
         <text-prop name=":hasCopyright">
             <text permissions="prop-default" encoding="xml">
@@ -368,22 +336,6 @@
         </date-prop>
         <text-prop name=":hasDescription">
             <text permissions="prop-default" encoding="utf8">Illustration of the poem "Liberté" by Paul Éluard.</text>
-            <text permissions="prop-default" encoding="xml">
-                Variations of the &lt;bitstream&gt;-Tag:
-                <ul>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Liberté, j'écris ton nom" has no "permissions"
-                        attribute, so an UnknownUser has no rights at all. A user who is not logged in doesn't see the
-                        image at all.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "Deluge" has permissions="prop-restricted", which gives
-                        an UnknownUser the right "RV" (Restricted view permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in should see a blurred image.</li>
-                    <li>The &lt;bitstream&gt;-Tag of resource "BM K.3375" has permissions="prop-default", which gives
-                        an UnknownUser the right "V" (View permission, see
-                        https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/#permissions). A user who is
-                        not logged in sees the image in full resolution.</li>
-                </ul>
-            </text>
         </text-prop>
         <text-prop name=":hasCopyright">
             <text permissions="prop-default" encoding="utf8">© Pierre Seghers, Paris</text>


### PR DESCRIPTION
 - remove the unnecessary texts about the variations of the <bitstream> tag (this is explained in the docs, and doesn't belong into rosetta)
 - make images of Deluge and Liberté visible for not-logged-in users
 - update .gitignore